### PR TITLE
Update installation requirements for compatibility

### DIFF
--- a/dependencies/requirements.yml
+++ b/dependencies/requirements.yml
@@ -4,14 +4,15 @@ channels:
   - conda-forge
 dependencies:
   - python=3
-  - ipykernel=5.4.2
-  - scipy=1.5.*
-  - networkx=2.4
-  - matplotlib=3.3.2
-  - tqdm=4.50.2
-  - numpy=1.19.4
-  - notebook=6.1.5
-  - jupyter=1.0.0
+  - pip
+  - ipykernel
+  - numpy
+  - scipy
+  - networkx
+  - matplotlib
+  - tqdm
+  - notebook
+  - jupyter
   - pip:
-    - qiskit==0.23.1
-    - pylatexenc==2.7
+    - qiskit
+    - pylatexenc


### PR DESCRIPTION
The version requirements are still too stiff, and do not work under Linux. I removed all version requirements except `python=3`, and added `pip` as a dependency to be installed by `conda`. This version creates the environment under Linux (x86_64) without error. On a side note, we should support the latest version of the packages anyways.